### PR TITLE
Collect Debian Packages / Collect RPM Packages

### DIFF
--- a/Linux/OtterExtension/Operations/CollectDebianPackagesOperation.cs
+++ b/Linux/OtterExtension/Operations/CollectDebianPackagesOperation.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Inedo.Agents;
+using Inedo.Diagnostics;
+using Inedo.Documentation;
+using Inedo.Otter.Data;
+using Inedo.Otter.Extensibility;
+using Inedo.Otter.Extensibility.Operations;
+using Inedo.Otter.Extensions.Configurations;
+
+namespace Inedo.Extensions.Linux.Operations
+{
+    [DisplayName("Collect Debian Packages")]
+    [Description("Collects the names and versions of .deb packages installed on a server.")]
+    [ScriptAlias("Collect-DebianPackages")]
+    [ScriptNamespace("Linux", PreferUnqualified = true)]
+    public sealed class CollectDebianPackagesOperation : CollectOperation<DictionaryConfiguration>
+    {
+        public async override Task<DictionaryConfiguration> CollectConfigAsync(IOperationExecutionContext context)
+        {
+            var remoteExecuter = await context.Agent.GetServiceAsync<IRemoteProcessExecuter>().ConfigureAwait(false);
+            var packages = new List<Package>();
+
+            using (var process = remoteExecuter.CreateProcess(new RemoteProcessStartInfo
+            {
+                FileName = "/usr/bin/dpkg",
+                Arguments = "--list"
+            }))
+            {
+                process.OutputDataReceived += (s, e) =>
+                {
+                    // installed packages have ii at the start of the line.
+                    if (!e.Data.StartsWith("ii "))
+                        return;
+
+                    var parts = e.Data.Split(new[] { ' ' }, 4, StringSplitOptions.RemoveEmptyEntries);
+                    packages.Add(new Package(parts[1], parts[2]));
+                };
+                process.ErrorDataReceived += (s, e) =>
+                {
+                    this.LogWarning(e.Data);
+                };
+
+                process.Start();
+                await process.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+
+                if (process.ExitCode != 0)
+                {
+                    this.LogError($"\"dpkg --list\" exited with code {process.ExitCode}");
+                    return null;
+                }
+            }
+
+            using (var db = new DB.Context())
+            {
+                await db.ServerPackages_DeletePackagesAsync(
+                    Server_Id: context.ServerId,
+                    PackageType_Name: "Debian"
+                ).ConfigureAwait(false);
+
+                foreach (var package in packages)
+                {
+                    await db.ServerPackages_CreateOrUpdatePackageAsync(
+                        Server_Id: context.ServerId,
+                        PackageType_Name: "Debian",
+                        Package_Name: package.Name,
+                        Package_Version: package.Version,
+                        CollectedOn_Execution_Id: context.ExecutionId,
+                        Url_Text: null,
+                        CollectedFor_ServerRole_Id: context.ServerRoleId
+                    ).ConfigureAwait(false);
+                }
+            }
+
+            return null;
+        }
+
+        protected override ExtendedRichDescription GetDescription(IOperationConfiguration config)
+        {
+            return new ExtendedRichDescription(
+                new RichDescription("Collect Debian Packages")
+            );
+        }
+
+        private struct Package
+        {
+            public Package(string name, string version)
+            {
+                this.Name = name;
+                this.Version = version;
+            }
+
+            public string Name { get; }
+            public string Version { get; }
+        }
+    }
+}

--- a/Linux/OtterExtension/Operations/CollectRpmPackagesOperation.cs
+++ b/Linux/OtterExtension/Operations/CollectRpmPackagesOperation.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Inedo.Agents;
+using Inedo.Diagnostics;
+using Inedo.Documentation;
+using Inedo.Otter.Data;
+using Inedo.Otter.Extensibility;
+using Inedo.Otter.Extensibility.Operations;
+using Inedo.Otter.Extensions.Configurations;
+
+namespace Inedo.Extensions.Linux.Operations
+{
+    [DisplayName("Collect RPM Packages")]
+    [Description("Collects the names and versions of .rpm packages installed on a server.")]
+    [ScriptAlias("Collect-RpmPackages")]
+    [ScriptNamespace("Linux", PreferUnqualified = true)]
+    public sealed class CollectRpmPackagesOperation : CollectOperation<DictionaryConfiguration>
+    {
+        public async override Task<DictionaryConfiguration> CollectConfigAsync(IOperationExecutionContext context)
+        {
+            var remoteExecuter = await context.Agent.GetServiceAsync<IRemoteProcessExecuter>().ConfigureAwait(false);
+            var packages = new List<Package>();
+
+            using (var process = remoteExecuter.CreateProcess(new RemoteProcessStartInfo
+            {
+                FileName = "/usr/bin/rpm",
+                Arguments = "-qa"
+            }))
+            {
+                process.OutputDataReceived += (s, e) =>
+                {
+                    var parts = e.Data.Split(new[] { '-' }, 2);
+                    packages.Add(new Package(parts[0], parts[1]));
+                };
+                process.ErrorDataReceived += (s, e) =>
+                {
+                    this.LogWarning(e.Data);
+                };
+
+                process.Start();
+                await process.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+
+                if (process.ExitCode != 0)
+                {
+                    this.LogError($"\"rpm -qa\" exited with code {process.ExitCode}");
+                    return null;
+                }
+            }
+
+            using (var db = new DB.Context())
+            {
+                await db.ServerPackages_DeletePackagesAsync(
+                    Server_Id: context.ServerId,
+                    PackageType_Name: "RPM"
+                ).ConfigureAwait(false);
+
+                foreach (var package in packages)
+                {
+                    await db.ServerPackages_CreateOrUpdatePackageAsync(
+                        Server_Id: context.ServerId,
+                        PackageType_Name: "RPM",
+                        Package_Name: package.Name,
+                        Package_Version: package.Version,
+                        CollectedOn_Execution_Id: context.ExecutionId,
+                        Url_Text: null,
+                        CollectedFor_ServerRole_Id: context.ServerRoleId
+                    ).ConfigureAwait(false);
+                }
+            }
+
+            return null;
+        }
+
+        protected override ExtendedRichDescription GetDescription(IOperationConfiguration config)
+        {
+            return new ExtendedRichDescription(
+                new RichDescription("Collect RPM Packages")
+            );
+        }
+
+        private struct Package
+        {
+            public Package(string name, string version)
+            {
+                this.Name = name;
+                this.Version = version;
+            }
+
+            public string Name { get; }
+            public string Version { get; }
+        }
+    }
+}

--- a/Linux/OtterExtension/OtterExtension.csproj
+++ b/Linux/OtterExtension/OtterExtension.csproj
@@ -30,28 +30,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Inedo.Agents.Client, Version=419.2.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.Otter.SDK.1.3.0\lib\net45\Inedo.Agents.Client.dll</HintPath>
+    <Reference Include="Inedo.Agents.Client, Version=501.5.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.Otter.SDK.1.6.1\lib\net45\Inedo.Agents.Client.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Inedo.ExecutionEngine, Version=39.1.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.Otter.SDK.1.3.0\lib\net45\Inedo.ExecutionEngine.dll</HintPath>
+    <Reference Include="Inedo.ExecutionEngine, Version=59.1.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.Otter.SDK.1.6.1\lib\net45\Inedo.ExecutionEngine.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="InedoLib, Version=419.2.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.Otter.SDK.1.3.0\lib\net45\InedoLib.dll</HintPath>
+    <Reference Include="InedoLib, Version=501.5.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.Otter.SDK.1.6.1\lib\net45\InedoLib.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Otter.Web.Controls, Version=1.3.0.4, Culture=neutral, PublicKeyToken=4da0d93b7176269b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.Otter.SDK.1.3.0\lib\net45\Otter.Web.Controls.dll</HintPath>
+    <Reference Include="Otter.Web.Controls, Version=1.6.1.2, Culture=neutral, PublicKeyToken=4da0d93b7176269b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.Otter.SDK.1.6.1\lib\net45\Otter.Web.Controls.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="OtterCore, Version=1.3.0.4, Culture=neutral, PublicKeyToken=4da0d93b7176269b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.Otter.SDK.1.3.0\lib\net45\OtterCore.dll</HintPath>
+    <Reference Include="OtterCore, Version=1.6.1.2, Culture=neutral, PublicKeyToken=4da0d93b7176269b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.Otter.SDK.1.6.1\lib\net45\OtterCore.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -63,6 +63,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Operations\CollectDebianPackagesOperation.cs" />
+    <Compile Include="Operations\CollectRpmPackagesOperation.cs" />
     <Compile Include="Operations\SHEnsureOperation.cs" />
     <Compile Include="Operations\SHUtil.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Linux/OtterExtension/packages.config
+++ b/Linux/OtterExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Inedo.Otter.SDK" version="1.3.0" targetFramework="net45" />
+  <package id="Inedo.Otter.SDK" version="1.6.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Tested on Ubuntu 16.04 (a Debian-based distribution). I don't have access to a Red Hat, Fedora, or CentOS machine to test the RPM version on, but it's straightforward enough that it work if the Debian one does.

See #4 and #5.

This accompanies the Chocolatey (Inedo/inedox-chocolatey@1fd46bf3e5399bcc89fd3138e5585427e33c41cc), DSC (Inedo/inedox-windows@45ebd3d66d24ba914b86f1ed287341924b955193), and upack (Inedo/inedox-inedocore#24) collection operations.